### PR TITLE
Feat/gh73 adapter user preference

### DIFF
--- a/src/main/java/Services/UserPreferenceService/UserPreferenceBaseService.java
+++ b/src/main/java/Services/UserPreferenceService/UserPreferenceBaseService.java
@@ -1,0 +1,206 @@
+/*
+ * UserPreferenceBaseService.java
+ *
+ * Copyright (c) 2020-2022 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski, Antoine Théate
+ *
+ * This file is part of DEH-CommonJ
+ *
+ * The DEH-CommonJ is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-CommonJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Services.UserPreferenceService;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.text.MessageFormat;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@linkplain UserPreferenceBaseService} is the base user preference service for any user preference service
+ * 
+ * @param <TUserPreference> the type of user preference
+ */
+public abstract class UserPreferenceBaseService<TUserPreference>
+{
+    /**
+     * The current class logger
+     */
+    private final Logger logger = LogManager.getLogger();
+    
+    /**
+     * The name of folder where user preference is storage.
+     */
+    public static final String UserPreferenceDirectoryName = "UserPreferences";
+
+    /**
+     * The setting file extension
+     */
+    public static final String SettingFileExtension = ".settings.json";
+    
+    /**
+     * Gets the {@linkplain Class} of {@linkplain #TUserPreference}
+     */
+    protected abstract Class<TUserPreference> GetUserPreferenceType();
+
+    /**
+     * Gets the user preference file name
+     */
+    protected abstract String GetFileName();
+    
+    /**
+     * Backing field for {@linkplain GetUserPreference()}
+     */
+    private TUserPreference userPreference;
+    
+    /**
+     * Gets the {@linkplain IUserPreference} the {@linkplain UserPreferenceService} currently write and read from/to
+     * 
+     * @return a {@linkplain IUserPreference}
+     */    
+    public TUserPreference GetUserPreference()
+    {
+        if(this.userPreference == null)
+        {
+            this.Read();
+        }
+        
+        return this.userPreference;
+    }
+    
+    /**
+     * The {@linkplain File} that holds the user preferences
+     */
+    private File userPreferenceFile = this.GetSettingFile();
+    
+    /**
+     * Reads the {@linkplain IUserPreference} from the file
+     * 
+     * @return the {@linkplain TUserPreference}
+     */    
+    public TUserPreference Read()
+    {
+        if (!this.TryCreateDirectoryOrFile(this.userPreferenceFile))
+        {
+            throw new InvalidPathException(this.userPreferenceFile.getAbsolutePath(), "Cannot make use of the user preference service. Check the log for more detail"); 
+        }
+
+        try (FileInputStream reader = new FileInputStream(this.userPreferenceFile))
+        {
+            byte[] data = new byte[(int) this.userPreferenceFile.length()];
+            int read = reader.read(data);
+            
+            this.logger.info(String.format("%s bytes read from the UserPreference file ", read));
+            
+            String dataString = new String(data, StandardCharsets.UTF_8);
+            
+            this.userPreference = new Gson().fromJson(dataString, GetUserPreferenceType());
+            
+            if (this.userPreference == null)
+            {
+                this.userPreference = GetUserPreferenceType().newInstance();
+            }
+            
+            return this.userPreference;
+        }
+        catch (IOException | InstantiationException | IllegalAccessException exception)
+        {
+            this.logger.error(MessageFormat.format("Could not read the user setting file {0} because {1}", 
+                    this.userPreferenceFile.getAbsolutePath(),
+                    exception));
+            
+            return null;
+        }
+    }
+    
+    /**
+     * Saves the {@linkplain userPreference} to disk
+     */
+    public void Save()
+    {
+        if (!this.TryCreateDirectoryOrFile(this.userPreferenceFile))
+        {
+            throw new InvalidPathException(this.userPreferenceFile.getAbsolutePath(), "Cannot make use of the user preference service. Check the log for more detail"); 
+        }
+        
+        try (FileWriter writer = new FileWriter(this.userPreferenceFile.getAbsolutePath(), false))
+        {
+            writer.write(new Gson().toJson(this.userPreference)); 
+        } 
+        catch (IOException exception)
+        {
+            this.logger.error(MessageFormat.format("Could not write the user setting file {0} because {1}", 
+                    this.userPreferenceFile.getAbsolutePath(),
+                    exception));
+        }
+    }
+        
+    /**
+     * Gets the setting file
+     * 
+     * @return a {@linkplain File}
+     */
+    private File GetSettingFile()
+    {
+        File file = new File(System.getProperty("user.home"));
+        file = new File(file, ".rheagroup");
+        this.TryCreateDirectoryOrFile(file);
+        file = new File(file, "DEHAdapterSettingFile");
+        this.TryCreateDirectoryOrFile(file);
+        file = new File(file, UserPreferenceDirectoryName);
+        this.TryCreateDirectoryOrFile(file);
+        file = new File(file, this.GetFileName() + UserPreference.class.getSimpleName() + SettingFileExtension);
+        this.TryCreateDirectoryOrFile(file);
+        return file;
+    }
+
+    /**
+     * Create the directory if it does not exist yet
+     * 
+     * @param fileOrDirectory the {@linkplain File} containing the path
+     * @return a value indicating whether all checks on the {@linkplain file} are ok 
+     */
+    private boolean TryCreateDirectoryOrFile(File fileOrDirectory)
+    {
+        try 
+        {                
+            if(fileOrDirectory.getName().endsWith(SettingFileExtension) && !fileOrDirectory.exists())
+            {
+                return fileOrDirectory.createNewFile();
+            }
+            
+            if(!fileOrDirectory.exists() && fileOrDirectory.mkdir())
+            {
+                return fileOrDirectory.createNewFile();
+            }
+            
+            return fileOrDirectory.exists();
+        }
+        catch (IOException exception)
+        {
+            this.logger.error(MessageFormat.format("Could not create specified directory or file: {0}", fileOrDirectory.getAbsolutePath()));
+            this.logger.catching(exception);
+            return false;
+        }
+    }
+}

--- a/src/main/java/Services/UserPreferenceService/UserPreferenceService.java
+++ b/src/main/java/Services/UserPreferenceService/UserPreferenceService.java
@@ -23,176 +23,26 @@
  */
 package Services.UserPreferenceService;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.InvalidPathException;
-import java.text.MessageFormat;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import com.google.gson.Gson;
-
 /**
  * The {@linkplain UserPreferenceService} handles user preferences
  */
-public class UserPreferenceService implements IUserPreferenceService
+public class UserPreferenceService extends UserPreferenceBaseService<UserPreference> implements IUserPreferenceService
 {
     /**
-     * The current class logger
-     */
-    private final Logger logger = LogManager.getLogger();
-    
-    /**
-     * The name of folder where user preference is storage.
-     */
-    public static final String UserPreferenceDirectoryName = "UserPreferences";
-
-    /**
-     * The setting file extension
-     */
-    public static final String SettingFileExtension = ".settings.json";
-    
-    /**
-     * Backing field for {@linkplain GetUserPreference()}
-     */
-    private UserPreference userPreference;
-    
-    /**
-     * Gets the {@linkplain IUserPreference} the {@linkplain UserPreferenceService} currently write and read from/to
-     * 
-     * @return a {@linkplain IUserPreference}
+     * Gets the {@linkplain Class} of {@linkplain #TUserPreference}
      */
     @Override
-    public UserPreference GetUserPreference()
+    protected Class<UserPreference> GetUserPreferenceType()
     {
-        if(this.userPreference == null)
-        {
-            this.Read();
-        }
-        
-        return this.userPreference;
+        return UserPreference.class;
     }
-    
+
     /**
-     * The {@linkplain File} that holds the user preferences
-     */
-    private File userPreferenceFile = this.GetSettingFile();
-    
-    /**
-     * Reads the {@linkplain IUserPreference} from the file
-     * 
-     * @return the {@linkplain UserPreference}
+     * Gets the user preference file name
      */
     @Override
-    public UserPreference Read()
+    protected String GetFileName()
     {
-        if (!this.TryCreateDirectoryOrFile(this.userPreferenceFile))
-        {
-            throw new InvalidPathException(this.userPreferenceFile.getAbsolutePath(), "Cannot make use of the user preference service. Check the log for more detail"); 
-        }
-
-        try (FileInputStream reader = new FileInputStream(this.userPreferenceFile))
-        {
-            byte[] data = new byte[(int) this.userPreferenceFile.length()];
-            int read = reader.read(data);
-            
-            this.logger.info(String.format("%s bytes read from the UserPreference file ", read));
-            
-            String dataString = new String(data, StandardCharsets.UTF_8);
-            
-            this.userPreference = new Gson().fromJson(dataString, UserPreference.class);
-            
-            if (this.userPreference == null)
-            {
-                this.userPreference = new UserPreference();
-            }
-            
-            return this.userPreference;
-        }
-        catch (IOException exception)
-        {
-            this.logger.error(MessageFormat.format("Could not read the user setting file {0} because {1}", 
-                    this.userPreferenceFile.getAbsolutePath(),
-                    exception));
-            
-            return null;
-        }
+        return "";
     }
-    
-    /**
-     * Saves the {@linkplain userPreference} to disk
-     */
-    @Override
-    public void Save()
-    {
-        if (!this.TryCreateDirectoryOrFile(this.userPreferenceFile))
-        {
-            throw new InvalidPathException(this.userPreferenceFile.getAbsolutePath(), "Cannot make use of the user preference service. Check the log for more detail"); 
-        }
-        
-        try (FileWriter writer = new FileWriter(this.userPreferenceFile.getAbsolutePath(), false))
-        {
-            writer.write(new Gson().toJson(this.userPreference)); 
-        } 
-        catch (IOException exception)
-        {
-            this.logger.error(MessageFormat.format("Could not write the user setting file {0} because {1}", 
-                    this.userPreferenceFile.getAbsolutePath(),
-                    exception));
-        }
-    }
-        
-    /**
-     * Gets the setting file
-     * 
-     * @return a {@linkplain File}
-     */
-    private File GetSettingFile()
-    {
-        File file = new File(System.getProperty("user.home"));
-        file = new File(file, ".rheagroup");
-        this.TryCreateDirectoryOrFile(file);
-        file = new File(file, "DEHAdapterSettingFile");
-        this.TryCreateDirectoryOrFile(file);
-        file = new File(file, UserPreferenceDirectoryName);
-        this.TryCreateDirectoryOrFile(file);
-        file = new File(file, UserPreference.class.getSimpleName() + SettingFileExtension);
-        this.TryCreateDirectoryOrFile(file);
-        return file;
-    }
-
-    /**
-     * Create the directory if it does not exist yet
-     * 
-     * @param fileOrDirectory the {@linkplain File} containing the path
-     * @return a value indicating whether all checks on the {@linkplain file} are ok 
-     */
-    private boolean TryCreateDirectoryOrFile(File fileOrDirectory)
-    {
-        try 
-        {                
-            if(fileOrDirectory.getName().endsWith(SettingFileExtension) && !fileOrDirectory.exists())
-            {
-                return fileOrDirectory.createNewFile();
-            }
-            
-            if(!fileOrDirectory.exists() && fileOrDirectory.mkdir())
-            {
-                return fileOrDirectory.createNewFile();
-            }
-            
-            return fileOrDirectory.exists();
-        }
-        catch (IOException exception)
-        {
-            this.logger.error(MessageFormat.format("Could not create specified directory or file: {0}", fileOrDirectory.getAbsolutePath()));
-            this.logger.catching(exception);
-            return false;
-        }
-    }
-
 }

--- a/src/test/java/Services/UserPreferenceService/UserPreferenceServiceTest.java
+++ b/src/test/java/Services/UserPreferenceService/UserPreferenceServiceTest.java
@@ -61,7 +61,7 @@ class UserPreferenceServiceTest
         
         try
         {
-            Field sessionField = UserPreferenceService.class.getDeclaredField("userPreferenceFile");
+            Field sessionField = UserPreferenceBaseService.class.getDeclaredField("userPreferenceFile");
             sessionField.setAccessible(true);
             file = (File) sessionField.get(this.service);
         }
@@ -104,7 +104,7 @@ class UserPreferenceServiceTest
     {
         this.file = new File("target", "Test.js");
         file.createNewFile();
-        Field field = UserPreferenceService.class.getDeclaredField("userPreferenceFile");
+        Field field = UserPreferenceBaseService.class.getDeclaredField("userPreferenceFile");
         field.setAccessible(true);
 
         field.set(this.service, file);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-CommonJ/pulls) open
- [x] I have verified that I am following the DEH-CommonJ [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-CommonJ/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- [x] Implemented a way for Dst tool adapters to have their own user preference service such as in RHEAGROUP/DEH-Capella#73
<!-- Thanks for contributingto DEH-CommonJ! -->